### PR TITLE
fix: Back port fixes from ibmi branch

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -13,6 +13,7 @@ pipeline {
         CXX = 'g++'
         CPPFLAGS = "-I/QOpenSys/pkgs/include -I/QOpenSys/pkgs/include/ncurses -D_ALL_SOURCE -D_XOPEN_SOURCE=700"
         LDFLAGS = '-L/QOpenSys/pkgs/lib'
+        LDFLAGS_NODIST = '-lutil'
         ARFLAGS="-X64 rc"
         ac_cv_func_clock_settime = "no"
         ac_cv_func_posix_fadvise = "no"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,7 +1,7 @@
 pipeline {
   agent {
     node {
-      label 'ibmi7.2'
+      label 'ibmi7.2-debug'
     }
 
   }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -72,10 +72,17 @@ pipeline {
     }
     stage('test') {
       steps {
-        timeout(20) {
-          sh 'make EXTRATESTOPTS=-v buildbottest'
+        timeout(90) {
+          sh "make buildbottest 'TESTOPTS=-j2 --junit-xml test-results-raw.xml'"
         }
       }
+    }
+  }
+
+  post {
+    always {
+      sh 'python3.6 cpython-to-junit.py test-results-raw.xml test-results.xml'
+      junit 'test-results.xml'
     }
   }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -15,6 +15,7 @@ pipeline {
         LDFLAGS = '-L/QOpenSys/pkgs/lib'
         LDFLAGS_NODIST = '-lutil'
         ARFLAGS="-X64 rc"
+        CCSHARED = '-fPIC'
         ac_cv_func_clock_settime = "no"
         ac_cv_func_posix_fadvise = "no"
         ac_cv_func_posix_fallocate = "no"
@@ -47,7 +48,7 @@ pipeline {
           --with-ensurepip=no \
           --with-tcltk-includes="$(pkg-config --cflags tk)" \
           --with-tcltk-libs="$(pkg-config --libs tk)" \
-          --without-computed-gotos \
+          --with-computed-gotos \
           --enable-ipv6 \
           --enable-loadable-sqlite-extensions \
           --enable-shared \

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -19,9 +19,12 @@ pipeline {
         ac_cv_func_clock_settime = "no"
         ac_cv_func_posix_fadvise = "no"
         ac_cv_func_posix_fallocate = "no"
+        ac_cv_func_sched_get_priority_max = "no"
         ac_cv_func_sched_rr_get_interval = "no"
+        ac_cv_func_sched_setaffinity = "no"
         ac_cv_func_sched_setparam = "no"
         ac_cv_func_sched_setscheduler = "no"
+        ac_cv_func_fexecve = "no"
         ac_cv_func_faccessat = "no"
         ac_cv_func_fchmodat = "no"
         ac_cv_func_fchownat = "no"
@@ -37,6 +40,9 @@ pipeline {
         ac_cv_func_symlinkat = "no"
         ac_cv_func_unlinkat = "no"
         ac_cv_func_utimensat = "no"
+        ac_cv_func_shm_open = "no"
+        ac_cv_func_shm_unlink = "no"
+        ac_cv_func_setregid = "no"
       }
       steps {
         sh 'cp /QOpenSys/jenkins/python.cache config.cache || :'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,7 +1,7 @@
 pipeline {
   agent {
     node {
-      label 'ibmi'
+      label 'ibmi7.2'
     }
 
   }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -43,6 +43,7 @@ pipeline {
         ac_cv_func_shm_open = "no"
         ac_cv_func_shm_unlink = "no"
         ac_cv_func_setregid = "no"
+        ac_cv_enable_visibility = "no"
       }
       steps {
         sh 'cp /QOpenSys/jenkins/python.cache config.cache || :'

--- a/Modules/_io/fileio.c
+++ b/Modules/_io/fileio.c
@@ -199,7 +199,7 @@ fileio_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
     return (PyObject *) self;
 }
 
-#ifdef O_CLOEXEC
+#if defined(O_CLOEXEC) && O_CLOEXEC <= 0xFFFFFFFF
 extern int _Py_open_cloexec_works;
 #endif
 
@@ -242,7 +242,7 @@ _io_FileIO___init___impl(fileio *self, PyObject *nameobj, const char *mode,
     int flags = 0;
     int fd = -1;
     int fd_is_own = 0;
-#ifdef O_CLOEXEC
+#if defined(O_CLOEXEC) && O_CLOEXEC <= 0xFFFFFFFF
     int *atomic_flag_works = &_Py_open_cloexec_works;
 #elif !defined(MS_WINDOWS)
     int *atomic_flag_works = NULL;

--- a/Modules/_multiprocessing/semaphore.c
+++ b/Modules/_multiprocessing/semaphore.c
@@ -9,8 +9,6 @@
 
 #include "multiprocessing.h"
 
-#define USE_UNNAMED_SEMAPHORES
-
 enum { RECURSIVE_MUTEX, SEMAPHORE };
 
 typedef struct {
@@ -187,18 +185,8 @@ semlock_release(SemLockObject *self, PyObject *args)
 
 #define SEM_CLEAR_ERROR()
 #define SEM_GET_LAST_ERROR() 0
-#ifdef USE_UNNAMED_SEMAPHORES
-static SEM_HANDLE SEM_CREATE(char* name, int val, int max) {
-    SEM_HANDLE ret = malloc(sizeof(sem_t));
-    if(sem_init(ret, 1, val))
-        return SEM_FAILED;
-    return ret;
-}
-#define SEM_CLOSE(sem) {sem_destroy(sem); free(sem);}
-#else
 #define SEM_CREATE(name, val, max) sem_open(name, O_CREAT | O_EXCL, 0600, val)
 #define SEM_CLOSE(sem) sem_close(sem)
-#endif
 #define SEM_GETVALUE(sem, pval) sem_getvalue(sem, pval)
 #define SEM_UNLINK(name) sem_unlink(name)
 
@@ -469,10 +457,9 @@ semlock_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
     /* On Windows we should fail if GetLastError()==ERROR_ALREADY_EXISTS */
     if (handle == SEM_FAILED || SEM_GET_LAST_ERROR() != 0)
         goto failure;
-#ifndef USE_UNNAMED_SEMAPHORES
+
     if (unlink && SEM_UNLINK(name) < 0)
         goto failure;
-#endif
 
     result = newsemlockobject(type, handle, kind, maxvalue, name_copy);
     if (!result)
@@ -621,10 +608,8 @@ static PyMethodDef semlock_methods[] = {
      "get the value of the semaphore"},
     {"_is_zero", (PyCFunction)semlock_iszero, METH_NOARGS,
      "returns whether semaphore has value zero"},
-#ifndef USE_UNNAMED_SEMAPHORES
     {"_rebuild", (PyCFunction)semlock_rebuild, METH_VARARGS | METH_CLASS,
      ""},
-#endif
     {"_after_fork", (PyCFunction)semlock_afterfork, METH_NOARGS,
      "rezero the net acquisition count after fork()"},
     {NULL}

--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -401,6 +401,10 @@ static int win32_can_symlink = 0;
 
 #define DWORD_MAX 4294967295U
 
+#if defined(O_CLOEXEC) && O_CLOEXEC > 0xFFFFFFFF
+#undef O_CLOEXEC
+#endif
+
 #ifdef MS_WINDOWS
 #define INITFUNC PyInit_nt
 #define MODNAME "nt"

--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -12650,7 +12650,7 @@ all_ins(PyObject *m)
     /* Must be a directory.      */
     if (PyModule_AddIntMacro(m, O_DIRECTORY)) return -1;
 #endif
-#ifdef O_NOFOLLOW
+#if defined(O_NOFOLLOW) && O_NOFOLLOW <= 0xFFFFFFFF
     /* Do not follow links.      */
     if (PyModule_AddIntMacro(m, O_NOFOLLOW)) return -1;
 #endif

--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -405,6 +405,16 @@ static int win32_can_symlink = 0;
 #undef O_CLOEXEC
 #endif
 
+#if defined(__PASE__) && defined(O_SEARCH)
+/* O_SEARCH is not supported by PASE */
+#undef O_SEARCH
+
+/* Unfortunately, O_SEARCH is used in defining O_ACCMODE when _XOPEN_SOURCE >= 700 */
+/* Redefine it based on the non _XOPEN_SOURCE>=700 definition */
+#undef O_ACCMODE
+#define O_ACCMODE (O_RDONLY | O_WRONLY | O_RDWR)
+#endif
+
 #ifdef MS_WINDOWS
 #define INITFUNC PyInit_nt
 #define MODNAME "nt"

--- a/Modules/timemodule.c
+++ b/Modules/timemodule.c
@@ -30,6 +30,11 @@
 #endif /* MS_WINDOWS */
 #endif /* !__WATCOMC__ || __QNX__ */
 
+#ifdef __PASE__
+#undef CLOCK_PROCESS_CPUTIME_ID
+#undef CLOCK_THREAD_CPUTIME_ID
+#endif
+
 /* Forward declarations */
 static int pysleep(_PyTime_t);
 static PyObject* floattime(_Py_clock_info_t *info);

--- a/Modules/timemodule.c
+++ b/Modules/timemodule.c
@@ -206,11 +206,16 @@ time_clock_getres(PyObject *self, PyObject *args)
     if (!PyArg_ParseTuple(args, "i:clock_getres", &clk_id))
         return NULL;
 
+#ifdef __PASE__
+    tp.tv_sec = 0;
+    tp.tv_nsec = 1e+6;
+#else
     ret = clock_getres((clockid_t)clk_id, &tp);
     if (ret != 0) {
         PyErr_SetFromErrno(PyExc_OSError);
         return NULL;
     }
+#endif
 
     return PyFloat_FromDouble(tp.tv_sec + tp.tv_nsec * 1e-9);
 }
@@ -1000,10 +1005,14 @@ py_process_time(_Py_clock_info_t *info)
             info->implementation = function;
             info->monotonic = 1;
             info->adjustable = 0;
+    #ifdef __PASE__
+            info->resolution = 1e-3;
+    #else
             if (clock_getres(clk_id, &res) == 0)
                 info->resolution = res.tv_sec + res.tv_nsec * 1e-9;
             else
                 info->resolution = 1e-9;
+    #endif
         }
         return PyFloat_FromDouble(tp.tv_sec + tp.tv_nsec * 1e-9);
     }

--- a/Python/fileutils.c
+++ b/Python/fileutils.c
@@ -24,7 +24,7 @@ extern int winerror_to_errno(int);
 extern wchar_t* _Py_DecodeUTF8_surrogateescape(const char *s, Py_ssize_t size);
 #endif
 
-#ifdef O_CLOEXEC
+#ifdef O_CLOEXEC && O_CLOEXEC <= 0xFFFFFFFF
 /* Does open() support the O_CLOEXEC flag? Possible values:
 
    -1: unknown
@@ -1025,7 +1025,7 @@ _Py_open_impl(const char *pathname, int flags, int gil_held)
 
 #ifdef MS_WINDOWS
     flags |= O_NOINHERIT;
-#elif defined(O_CLOEXEC)
+#elif defined(O_CLOEXEC) && O_CLOEXEC <= 0xFFFFFFFF
     atomic_flag_works = &_Py_open_cloexec_works;
     flags |= O_CLOEXEC;
 #else

--- a/Python/pytime.c
+++ b/Python/pytime.c
@@ -612,10 +612,15 @@ pygettimeofday(_PyTime_t *tp, _Py_clock_info_t *info, int raise)
         info->implementation = "clock_gettime(CLOCK_REALTIME)";
         info->monotonic = 0;
         info->adjustable = 1;
-        if (clock_getres(CLOCK_REALTIME, &res) == 0)
+#ifdef __PASE__
+        info->resolution = 1e-3;
+#else
+        if (clock_getres(CLOCK_REALTIME, &res) == 0) {
             info->resolution = res.tv_sec + res.tv_nsec * 1e-9;
         else
             info->resolution = 1e-9;
+        }
+#endif
     }
 #else   /* HAVE_CLOCK_GETTIME */
 
@@ -752,11 +757,15 @@ pymonotonic(_PyTime_t *tp, _Py_clock_info_t *info, int raise)
         info->monotonic = 1;
         info->implementation = implementation;
         info->adjustable = 0;
+#ifdef __PASE__
+        info->resolution = 1e-3;
+#else
         if (clock_getres(clk_id, &res) != 0) {
             PyErr_SetFromErrno(PyExc_OSError);
             return -1;
         }
         info->resolution = res.tv_sec + res.tv_nsec * 1e-9;
+#endif
     }
     if (_PyTime_FromTimespec(tp, &ts, raise) < 0)
         return -1;

--- a/configure.ac
+++ b/configure.ac
@@ -3808,6 +3808,10 @@ AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
 
 # On some systems, setgroups is in unistd.h, on others, in grp.h
 AC_MSG_CHECKING(for setgroups)
+if test "$ac_sys_system" = "OS400"
+then
+  AC_MSG_RESULT(no)
+else
 AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
 #include <unistd.h>
 #ifdef HAVE_GRP_H
@@ -3818,6 +3822,7 @@ AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
    AC_MSG_RESULT(yes)],
   [AC_MSG_RESULT(no)
 ])
+fi
 
 # check for openpty and forkpty
 

--- a/cpython-to-junit.py
+++ b/cpython-to-junit.py
@@ -1,0 +1,61 @@
+import xml.etree.ElementTree as ET
+import sys
+
+if len(sys.argv) < 3:
+    print(f'{sys.argv} [input xml] [output xml]')
+    exit(1)
+
+dom = ET.parse(sys.argv[1])
+testsuites = dom.getroot()
+
+remove = []
+
+for testsuite in testsuites:
+    testsuite.attrib['timestamp'] = testsuite.attrib['start']
+    del testsuite.attrib['start']
+
+    # We can't remove the testcases in a direct for loop since that
+    # messes up the iterator, so we use a list comprehension and a
+    # tuple to process it completely before entering this loop
+    for testcase in ([_ for _ in testsuite if 'name' not in _.attrib]):
+        testsuite.remove(testcase)
+
+    if len(testsuite) == 0:
+        # We can't remove now or it will mess up the outer loop
+        # So we save it off to be removed later
+        remove.append((testsuites, testsuite))
+        continue
+    
+    for testcase in testsuite:
+        tokens = testcase.attrib['name'].split('.')
+
+        try:
+            classname = tokens[-2]
+
+            if classname[0].isupper():
+                tokens = tokens[:-2]
+            else:
+                tokens = tokens[:-1]
+            
+            break
+        except IndexError:
+            continue
+
+    testsuite.attrib['name'] = '.'.join(tokens)
+
+
+    for testcase in testsuite:
+        for attr in tuple(testcase.attrib.keys()):
+            if attr not in ('name', 'time', 'classname', 'group'):
+                testcase.attrib.pop(attr)
+        
+        for elem in testcase:
+            if elem.tag == 'output':
+                elem.tag = 'failure'
+        
+for parent, child in remove:
+    parent.remove(child)
+
+    
+with open(sys.argv[2], 'wb') as out:
+    out.write(ET.tostring(testsuites))


### PR DESCRIPTION
Back ports changes from [ibmi branch](https://github.com/kadler/cpython/tree/ibmi) ->  [ibmi-3.6 branch](https://github.com/kadler/cpython/tree/ibmi-3.6) where applicable

Some commits were not back ported:

- Skipped 6e52f79d09867e6bf2b996ca9e35d952cadfffa3 because `Lib/multiprocessing/resource_tracker.py` not in 3.6
- Skiped 79206a87367a6de6f961ca67cd65a59ff03bf743 because `os.posix_spawn` not in 3.6 (new in 3.8)


Commits that lead to merge conflicts were:

- bc1861bb3d9f789495bfc6edeb4dc5f77a70efe9
- c87f0993ed
- 436ed3214996c910178d6568c091af8a47591826
- a74e076132e10ab4796d0a4057b08bfa3991d4a1

